### PR TITLE
Rename and edit intro section of simulate

### DIFF
--- a/docs/how_to_videos/model/general.mdx
+++ b/docs/how_to_videos/model/general.mdx
@@ -8,7 +8,7 @@ import { Vimeo } from '@site/src/components/Vimeo';
 
 ## Importing an Advanced Model
 
-This tutorial shows how quickly you can import an Advanced Model with the given data source.
+This tutorial shows how quickly you can import an Advanced Model on ValQ
 
 <Vimeo
     video="https://player.vimeo.com/video/439170391"

--- a/docs/how_to_videos/simulate/intro.mdx
+++ b/docs/how_to_videos/simulate/intro.mdx
@@ -1,14 +1,13 @@
 ---
 id: intro
 title: Introduction
-sidebar_label: 1. Introduction to Navigation Panel
+sidebar_label: 1. Overview
 ---
 
 import useBaseUrl from '@docusaurus/useBaseUrl'; // Add to the top of the file below the front matter.
 import { Vimeo } from '@site/src/components/Vimeo';
 
-
-Learn how to simulate your business models.
+As your ValQ learning journey continues, we now enter the next important business cycle which is represented by 'Simulate' tab
 
 <Vimeo
     video="https://player.vimeo.com/video/439200899"


### PR DESCRIPTION
- Renaming the simulate section 'Introduction to Navigation Panel' to 'Overview'
- Keeping the original video caption